### PR TITLE
add: access token and additional datasources

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,9 +78,11 @@
     "sinon": "^7.1.0"
   },
   "dependencies": {
+    "apollo-datasource-rest": "^0.4.0",
     "apollo-server-express": "^2.1.0",
     "fs-extra": "^7.0.0",
-    "got": "^9.2.2"
+    "got": "^9.2.2",
+    "graphql": "^14.3.1"
   },
   "engines": {
     "node": ">=8.10"

--- a/src/simpleServerWithContext.js
+++ b/src/simpleServerWithContext.js
@@ -16,10 +16,14 @@ module.exports = async (
   context: {
     cmsHost: string,
     jsonApiPrefix: string,
+    access_token: string,
   },
+  // TODO: merge these into an options object so that there is no need to
+  // pass null arguments
   additionalTypeDefs: Array<Promise<TypeDefinitions>> = [],
   additionalResolvers: ResolverMap = {},
-  additionalSchemaDirectives: SchemaDirectives = {}
+  additionalSchemaDirectives: SchemaDirectives = {},
+  additionalDataSources: any = {}
 ) =>
   new ApolloServer({
     typeDefs: await Promise.all(directives.concat(additionalTypeDefs)),
@@ -32,6 +36,9 @@ module.exports = async (
       schemaDirectives,
       additionalSchemaDirectives
     ),
+    dataSources: () => {
+      return additionalDataSources;
+    },
     context,
     // This is the same check made by the Apollo Server to enable/disable
     // introspection in production.

--- a/src/simpleServerWithContext.test.js
+++ b/src/simpleServerWithContext.test.js
@@ -3,17 +3,25 @@ const ase = require('apollo-server-express');
 jest.spyOn(ase, 'ApolloServer').mockImplementation(() => 0);
 
 const simpleServerWithContext = require('./simpleServerWithContext');
+const { RESTDataSource } = require('apollo-datasource-rest');
+
+class TestAPI extends RESTDataSource {}
 
 describe('simpleServerWithContext', () => {
   afterEach(() => {
     ase.ApolloServer.mockReset();
   });
+
   it('can instantiate the ApolloServer', async () => {
-    expect.assertions(5);
+    expect.assertions(6);
     const apolloServer = await simpleServerWithContext(
       { foo: 'bar' },
       [Promise.resolve('{}'), Promise.resolve('Pi')],
-      { the: () => 'resolver' }
+      { the: () => 'resolver' },
+      null,
+      {
+        testApi: new TestAPI(),
+      }
     );
     const apolloArgs = ase.ApolloServer.mock.calls[0][0];
     expect(apolloServer).toBeInstanceOf(ase.ApolloServer);
@@ -21,7 +29,9 @@ describe('simpleServerWithContext', () => {
     expect(Object.keys(apolloArgs.resolvers)).toEqual(['Query', 'the']);
     expect(Object.keys(apolloArgs.schemaDirectives)).toHaveLength(1);
     expect(Object.keys(apolloArgs.typeDefs)).toHaveLength(3);
+    expect(Object.keys(apolloArgs.dataSources())).toEqual(['testApi']);
   });
+
   it('can instantiate the ApolloServer with defaults', async () => {
     expect.assertions(5);
     const apolloServer = await simpleServerWithContext({ foo: 'bar' });


### PR DESCRIPTION
Allows for passing of an access token to the context object for use with datasources requiring authentication.